### PR TITLE
Tom's suggested wording for the rules

### DIFF
--- a/draft-welzl-ccwg-ratelimited-increase.md
+++ b/draft-welzl-ccwg-ratelimited-increase.md
@@ -93,7 +93,7 @@ This document uses the terms defined in {{Section 2 of !RFC5681}}.
 
 # Increase rules {#rules}
 
-When not operating in a recovery state (i.e., recovering from recent losses or ECN marking), a transport protocol MUST support a way to detect that it is likely to be rate-limited if it were to increase its cwnd.  One possible approach, when supporting bulk-transfer applications, would be to detect conditions in which the amount of unsent data in the transmit buffer is unlikely to allow the protocol to fully realize the corresponding FlightSize over the next RTT.  Other application sending patterns may lead to different heuristics, however.
+When not operating in a recovery state (i.e., recovering from recent losses), a transport protocol MUST support a way to detect that it is likely to be rate-limited if it were to increase its cwnd.  One possible approach, when supporting bulk-transfer applications, would be to detect conditions in which the amount of unsent data in the transmit buffer is unlikely to allow the protocol to fully realize the corresponding FlightSize over the next RTT.  Other application sending patterns may lead to different heuristics, however.
 
 When in a rate-limited state, senders of congestion controlled transport protocols:
 

--- a/draft-welzl-ccwg-ratelimited-increase.md
+++ b/draft-welzl-ccwg-ratelimited-increase.md
@@ -93,7 +93,9 @@ This document uses the terms defined in {{Section 2 of !RFC5681}}.
 
 # Increase rules {#rules}
 
-Irrespective of the current state of a congestion control mechanism, senders of congestion controlled transport protocols:
+When not operating in a recovery state (i.e., recovering from recent losses or ECN marking), a transport protocol MUST support a way to detect that it is likely to be rate-limited if it were to increase its cwnd.  One possible approach, when supporting bulk-transfer applications, would be to detect conditions in which the amount of unsent data in the transmit buffer is unlikely to allow the protocol to fully realize the corresponding FlightSize over the next RTT.  Other application sending patterns may lead to different heuristics, however.
+
+When in a rate-limited state, senders of congestion controlled transport protocols:
 
 1. MUST include a way to limit the growth of cwnd when FlightSize < cwnd.
 2. SHOULD limit the growth of cwnd when FlightSize < cwnd with inc(maxFS).


### PR DESCRIPTION
To better allow for pacing. One change: I removed "or ECN marking" because I didn't think an ECN mark puts TCP into a "recovery state"?  and indeed, why would our rules not apply immediately after getting an ECN mark?  E.g., thinking of Prague, this doesn't necessarily mean a huge backoff.