### PR TITLE
Making the limit() sentence about in-flight bytes, not the RTT

### DIFF
--- a/draft-ietf-ccwg-ratelimited-increase.md
+++ b/draft-ietf-ccwg-ratelimited-increase.md
@@ -114,7 +114,7 @@ When FlightSize < cwnd, regardless of the current state of a congestion control 
 1. MUST cap cwnd to be no larger than limit(maxFS).
 2. MAY restrict maxFS as min(maxFS, pipeACK), using "pipeACK" as defined in {{!RFC7661}}.
 
-In rule #1, the function limit() returns the maximum cwnd value the congestion control algorithm would yield by increasing for every ACK that is caused by segments in flight, starting from the value of the maxFS parameter.
+In rule #1, the function limit() returns the maximum cwnd value the congestion control algorithm would yield by increasing for every ACK that is caused by bytes in flight, starting from the value of the maxFS parameter.
 The RTT includes the minimum path propagation delay plus any delay accumulated by queing in the stack, at the interface and in network elements along the path.
 For example, for Slow Start, as specified in {{!RFC5681}}, limit(maxFS)=2*maxFS, such that equation 2 in {{!RFC5681}} becomes:
 


### PR DESCRIPTION
Closes #61 