### PR TITLE
Revise recommendation language in congestion control document

### DIFF
--- a/draft-ietf-ccwg-ratelimited-increase.md
+++ b/draft-ietf-ccwg-ratelimited-increase.md
@@ -93,7 +93,8 @@ become larger than the current flight size.
 In contrast, this present document concerns the increase in cwnd when a sender is rate-limited. These two topics are distinct,
 but are related, because both describe the management of the cwnd when the sender does not fully utilise the current cwnd.
 
-This document specifies a uniform rule that congestion control algorithms MUST apply and provides a recommendation that congestion control implementations SHOULD follow.
+This document specifies a uniform rule that congestion control algorithms MUST apply and provides a recommendation that congestion control implementations ought to follow.
+
 An appendix provides an overview of the divergence in current RFCs and some current implementations regarding cwnd increase when the sender is rate-limited.
 
 ## Terminology


### PR DESCRIPTION
Updated recommendation language from 'SHOULD' to 'ought to' for clarity.