### PR TITLE
Correct text around CWV

### DIFF
--- a/draft-ietf-ccwg-ratelimited-increase.md
+++ b/draft-ietf-ccwg-ratelimited-increase.md
@@ -116,7 +116,6 @@ When FlightSize < cwnd, regardless of the current state of a congestion control 
 2. MAY restrict maxFS as min(maxFS, pipeACK), using "pipeACK" as defined in {{!RFC7661}}.
 
 In rule #1, the function limit() returns the maximum cwnd value the congestion control algorithm would yield by increasing for every ACK that is caused by bytes in flight, starting from the value of the maxFS parameter.
-The RTT includes the minimum path propagation delay plus any delay accumulated by queing in the stack, at the interface and in network elements along the path.
 For example, for Slow Start, as specified in {{!RFC5681}}, limit(maxFS)=2*maxFS, such that equation 2 in {{!RFC5681}} becomes:
 
 ~~~
@@ -133,7 +132,7 @@ cwnd = min(cwnd_new, SMSS+maxFS)
 ~~~
 where cwnd and SMSS follow their definitions in {{!RFC5681}}.
 
-As with cwnd, without a way to reduce it when the transport sender becomes rate-limited, rule #1 allows for maxFS to stay valid for a long time, possibly not reflecting the reality of the end-to-end Internet path in use. For cwnd, this is remedied by "Congestion Window Validation" in {{!RFC7661}}, which also defines a "pipeACK" variable that measures the acknowledged size of the network pipe when the sender is rate-limited. Accordingly, to implement CWV, rule #2 can be used.
+As with cwnd, without a way to reduce it when the transport sender becomes rate-limited, rule #1 allows for maxFS to stay valid for a long time, possibly not reflecting the reality of the end-to-end Internet path in use. For cwnd, this is remedied by "Congestion Window Validation" in {{!RFC7661}}, which also defines a "pipeACK" variable that measures the acknowledged size of the network pipe when the sender is rate-limited. Accordingly, to be more cautious when the FS varies over time, rule #2 can be used.
 
 ## Example
 We illustrate the working of the rules by showing the increase of cwnd in two scenarios: when the growth of cwnd is unconstrained, and when it is constrained by the increase rules. In both cases we assume initial cwnd (initcwnd) = 10 segments, as defined for TCP in {{?RFC6928}}, QUIC in {{?RFC9002}}, a single connection begins with Slow Start, the sender transmits a total of 14 segments but pauses after transmitting 10 segments and resumes the transmission for the remaining 4 segments afterwards, no packets are lost, and an ACK is sent for every packet.


### PR DESCRIPTION
Remove RTT sentence (true, but RTT was not mentioned). newCWV says nothing about increasing or mainitaining CWND (only that if the CWND was larger than the recent FS, aka PipeACK, then use PipeACK as a basis for reducing CWND). So, rephrase Rule 2 as being more cautious ...