### PR TITLE
Remove old rule 2; provide rule for maxFS

### DIFF
--- a/draft-ietf-ccwg-ratelimited-increase.md
+++ b/draft-ietf-ccwg-ratelimited-increase.md
@@ -104,7 +104,7 @@ An appendix provides an overview of the divergence in current RFCs and some curr
 This document uses the terms defined in {{Section 2 of !RFC5681}} and {{Section 3 of !RFC7661}}. Additionally, we define:
 
 - maxFS: the largest value of FlightSize since the last time that cwnd was decreased. If cwnd has never been decreased, maxFS is the maximum value of FlightSize since the start of the data transfer.
-- initcwnd: The initial value of the congestion window, also known as the "initial window".
+- initcwnd: The initial value of the congestion window, also known as the "initial window" ("IW" in {{!RFC5681}}).
 
 # Increase rules {#rules}
 


### PR DESCRIPTION
Updated references and clarified rules for congestion window management in rate-limited scenarios. Improved language for consistency and clarity throughout the document.