### PR TITLE
Make RFC7661 is Informational.

### DIFF
--- a/draft-ietf-ccwg-ratelimited-increase.md
+++ b/draft-ietf-ccwg-ratelimited-increase.md
@@ -88,7 +88,7 @@ It could also occur because the receiver has limited the sender using flow contr
 (e.g., by the advertised TCP receiver window (rwnd) or by the connection or stream flow credit in QUIC).
 Current RFCs specifying congestion control algorithms diverge regarding the rules for increasing the cwnd when the sender is rate-limited.
 
-Congestion Window Validation (CWV) {{!RFC7661}} provides an experimental specification defining how to manage a cwnd that has
+Congestion Window Validation (CWV) {{?RFC7661}} provides an experimental specification defining how to manage a cwnd that has
 become larger than the current flight size, and how to respond to detected congestion when this is the case.
 In contrast, this present document concerns the increase in cwnd when a sender is rate-limited. These two topics are distinct,
 but are related, because both describe the management of the cwnd when a sender does not fully utilise the current cwnd.
@@ -104,8 +104,12 @@ Another appendix provides an overview of the divergence in current RFCs and some
 
 ## Terminology
 
-This document uses the terms defined in {{Section 2 of !RFC5681}} and {{Section 3 of !RFC7661}}. Additionally, we define:
+This document uses the terms defined in {{Section 2 of !RFC5681}}.
 
+Additionally, the following are defined:
+
+- cwnd-limited: A TCP flow that has sent the maximum number of segments permitted by the cwnd, where the application utilises the allowed sending rate {Section 4.5.3 of of ?RFC7661}.
+- rate-limited: A TCP flow that does not consume more than one half of cwnd and hence operates in the non-validated phase.  This includes periods when an application is either idle or chooses to send at a rate less than the maximum permitted by the cwnd {Section 3 of ?RFC7661}.
 - initcwnd: The initial value of the congestion window, also known as the "initial window" ("IW" in {{!RFC5681}}).
 - maxFS: the largest value of FlightSize since the last time that cwnd was decreased. If cwnd has never been decreased, maxFS is the maximum value of FlightSize since the start of the data transfer, and at least as large as initcwnd.
 
@@ -140,7 +144,7 @@ cwnd = min(cwnd_new, SMSS+maxFS)
 ~~~
 where cwnd and SMSS follow their definitions in {{!RFC5681}}.
 
-NOTE: This specification defines the current method used to increase the cwnd for a rate-limited sender. Without a way to reduce cwnd when the transport sender becomes rate-limited, maxFS can stay valid for a long time, possibly not reflecting the reality of the end-to-end Internet path in use. This is remedied by "Congestion Window Validation" in {{!RFC7661}}, which also defines a "pipeACK" variable that measures the recently acknowledged size of the network pipe when the sender was rate-limited.
+NOTE: This specification defines the current method used to increase the cwnd for a rate-limited sender. Without a way to reduce cwnd when the transport sender becomes rate-limited, maxFS can stay valid for a long time, possibly not reflecting the reality of the end-to-end Internet path in use. This can be remedied by "Congestion Window Validation" in {{?RFC7661}}, which also defines a "pipeACK" variable that measures the recently acknowledged size of the network pipe when the sender was rate-limited.
 
 ## Example
 We illustrate the working of Rate-Limited Increase by showing the increase of cwnd in two scenarios: when the growth of cwnd is unconstrained, and when the rate-limited sender is constrained by Rate-Limited Increase. For simplicity, this example accounts for the cwnd in segments, rather than bytes. In both cases, we assume the initial cwnd (initcwnd) = 10 segments, as defined for TCP in {{?RFC6928}} and QUIC in {{?RFC9002}}, a single connection begins with Slow Start, the sender transmits a total of 14 segments but pauses after transmitting 10 segments and resumes the transmission for the remaining 4 segments afterwards, no packets are lost, and an ACK is sent for every packet.
@@ -319,7 +323,7 @@ RFC-Ed Note: This section is provided as input for IETF discussion, and should b
 
 ### Specification
 
-{{!RFC7661}} suggests there is no increase limitation in the standard TCP behavior (which {{!RFC7661}} changes), on page 4:
+{{?RFC7661}} suggested there was no increase limitation in the standard TCP behavior (which {{?RFC7661}} changes), on page 4:
 
 >Standard TCP does not impose additional restrictions on the growth of
 the congestion window when a TCP sender is unable to send at the


### PR DESCRIPTION
This change requires changes to the way this is used and to import rather than normatively rely on terminology from RFC7661.