### PR TITLE
Move appendix, update change log, RFC 7661 ref normative

### DIFF
--- a/draft-ietf-ccwg-ratelimited-increase.md
+++ b/draft-ietf-ccwg-ratelimited-increase.md
@@ -215,7 +215,7 @@ implements Rate-Limited Increase in the `tcp_is_cwnd_limited` function in `tcp.h
 
 ### Assessment
 
-Linux implements a limit to cwnd growth in accordance with Rate-Limited Increase;
+Linux currently implements a limit to cwnd growth in accordance with Rate-Limited Increase;
 in Slow Start, this limit follows the rule's upper limit, while in Congestion Avoidance, it is more conservative than Rate-Limited Increase.
 The specification and the ns-2 and (older) ns-3 implementations are in conflict with Rate-Limited Increase.
 

--- a/draft-ietf-ccwg-ratelimited-increase.md
+++ b/draft-ietf-ccwg-ratelimited-increase.md
@@ -186,7 +186,7 @@ Pacing mechanisms seek to avoid the negative impacts associated with "bursts" (f
 ### Update
 
 A DCCP Congestion Control ID (CCID) specifying TCP-like behaviour ought to follow the method specified in this document. The current guidance relates only to {{?RFC2861}}.
-The text in {{Section 5.1 of !RFC4341}} is updated by this document to specify the management of the
+The text in {{Section 5.1 of !RFC4341}} is updated by this document by adding the text in ({{rules}}) of this document to specify the management of the
 cwnd when the sender is rate-limited.
 
 

--- a/draft-ietf-ccwg-ratelimited-increase.md
+++ b/draft-ietf-ccwg-ratelimited-increase.md
@@ -268,7 +268,7 @@ in Section 7.2.1. It is thus implicitly clear that the quoted rule only applies 
 
 ### Assessment
 
-With the exception of pacing, this specification conservatively limits the growth in cwnd, similar to Cubic and SCTP. It is in accordance with Rate-Limited Increase, and more conservative.
+With the exception of pacing, the QUIC specification conservatively limits the growth in cwnd, similar to Cubic and SCTP. It is in accordance with Rate-Limited Increase, and more conservative.
 
 
 # Security Considerations

--- a/draft-ietf-ccwg-ratelimited-increase.md
+++ b/draft-ietf-ccwg-ratelimited-increase.md
@@ -85,7 +85,7 @@ even though the congestion control rules would allow it to transmit data.
 This could occur because the application has not provided sufficient data to fully utilize the congestion window (cwnd).
 It could also occur because the receiver has limited the sender using flow control
 (e.g., by the advertised TCP receiver window (rwnd) or by the connection or stream flow credit in QUIC).
-Current RFCs specifying congestion control algorithms diverge regarding the rules for increasing the cwnd when the sender is rate-limited. This document provides a uniform rule in ({{rules}}), and specifies updates to RFCs 4341, 5681, 9002, 9260, and 9438 in ({{rfc-updates}}).
+Current RFCs specifying congestion control algorithms diverge regarding the rules for increasing the cwnd when the sender is rate-limited. This document provides a uniform behavior in ({{rules}}), and specifies updates to RFCs 4341, 5681, 9002, 9260, and 9438 in ({{rfc-updates}}).
 
 Congestion Window Validation (CWV) {{?RFC7661}} provides an experimental specification defining how to manage a cwnd that has
 become larger than the current flight size, and how to respond to detected congestion when this is the case.

--- a/draft-ietf-ccwg-ratelimited-increase.md
+++ b/draft-ietf-ccwg-ratelimited-increase.md
@@ -72,7 +72,7 @@ I-D.ietf-ccwg-bbr:
 
 --- abstract
 
-This document specifies how transport protocols increase their congestion window when the sender is rate-limited, and updates RFC 4341, RFC 5681, RFC 9002, RFC 9260, and RFC 9438.
+This document specifies how transport protocols increase their congestion window when the sender is rate-limited, and updates RFCs 4341, 5681, 9002, 9260, and 9438.
 Such a limitation can be caused by the sending application not supplying data or by receiver flow control.
 
 
@@ -85,7 +85,7 @@ even though the congestion control rules would allow it to transmit data.
 This could occur because the application has not provided sufficient data to fully utilize the congestion window (cwnd).
 It could also occur because the receiver has limited the sender using flow control
 (e.g., by the advertised TCP receiver window (rwnd) or by the connection or stream flow credit in QUIC).
-Current RFCs specifying congestion control algorithms diverge regarding the rules for increasing the cwnd when the sender is rate-limited.
+Current RFCs specifying congestion control algorithms diverge regarding the rules for increasing the cwnd when the sender is rate-limited. This document provides a uniform rule in ({{rules}}), and specifies updates to RFCs 4341, 5681, 9002, 9260, and 9438 in ({{rfc-updates}}).
 
 Congestion Window Validation (CWV) {{?RFC7661}} provides an experimental specification defining how to manage a cwnd that has
 become larger than the current flight size, and how to respond to detected congestion when this is the case.
@@ -94,8 +94,6 @@ but are related, because both describe the management of the cwnd when a sender 
 
 An appendix provides an example of how rate-limited increase can play out.
 
-RFC-Ed Note, please remove the following sentence prior to publication:
-Another appendix provides an overview of the divergence in current RFCs and some implementations regarding cwnd increase when the sender is rate-limited (the second appendix is to be removed before publication).
 
 # Conventions and Definitions
 
@@ -173,6 +171,104 @@ Rate-based congestion control algorithms MUST NOT result in an unconstrained sit
 ### Pacing
 
 Pacing mechanisms seek to avoid the negative impacts associated with "bursts" (flights of packets transmitted back-to-back). Rate-Limited Increase introduces a limit using "maxFS", which is based on the number of bytes in flight during a previous RTT; thus, as long as the number of bytes in flight per RTT is unaffected by pacing, Rate-Limited Increase does not constrain the use of pacing mechanisms.
+
+
+# Updates to RFCs 4341, 5681, 9002, 9260, and 9438 {#rfc-updates}
+
+## RFC 4341: The Datagram Congestion Control Protocol (DCCP) CCID2
+
+### Specification
+
+{{Section 5.1 of !RFC4341}} states:
+
+>There are currently no standards governing TCP's use of the congestion window during an application-limited period.  In particular, it is possible for TCP's congestion window to grow quite large during a long uncongested period when the sender is application limited, sending at a low rate.  {{?RFC2861}} essentially suggests that TCP's congestion window not be increased during application-limited periods when the congestion window is not being fully utilized.
+
+### Update
+
+A DCCP Congestion Control ID (CCID) specifying TCP-like behaviour ought to follow the method specified in this document. The current guidance relates only to {{?RFC2861}}.
+The text in {{Section 5.1 of !RFC4341}} is updated by this document to specify the management of the
+cwnd when the sender is rate-limited.
+
+
+## TCP ("Reno" congestion control)
+
+### Specification
+
+{{?RFC7661}} suggested there was no increase limitation in the standard TCP behavior (which {{?RFC7661}} changes), on page 4:
+
+>Standard TCP does not impose additional restrictions on the growth of
+the congestion window when a TCP sender is unable to send at the
+maximum rate allowed by the cwnd. In this case, the rate-limited
+sender may grow a cwnd far beyond that corresponding to the current
+transmit rate, resulting in a value that does not reflect current
+information about the state of the network path the flow is using.
+
+### Implementation {#tcp-impl}
+
+- ns-2 allows cwnd to grow when it is rate-limited by rwnd. (Rate-limited by the sending application: not tested.)
+- Until release 3.42, ns-3 allowed cwnd to grow when rate-limited, either due to an application or rwnd limit.  Since release 3.42, ns-3 TCP models conform to Rate-Limited Increase, following the current Linux TCP approach in this regard (see next bullet).
+- In Congestion Avoidance, Linux only allows the cwnd to grow when the sender is unconstrained.
+Before kernel version 3.16, this also applied to Slow Start.
+The check for "unconstrained" is performed by checking if FlightSize is greater or equal to cwnd.
+Since kernel version 3.16, which was published in August 2014, in Slow Start, the increase
+implements Rate-Limited Increase in the `tcp_is_cwnd_limited` function in `tcp.h`.
+
+### Assessment
+
+Linux implements a limit to cwnd growth in accordance with Rate-Limited Increase;
+in Slow Start, this limit follows the rule's upper limit, while in Congestion Avoidance, it is more conservative than Rate-Limited Increase.
+The specification and the ns-2 and (older) ns-3 implementations are in conflict with Rate-Limited Increase.
+
+## CUBIC
+
+### Specification
+
+{{Section 5.8 of !RFC9438}} says:
+
+>Cubic doesn't increase cwnd when it's limited by the sending application or rwnd.
+
+### Implementation
+
+The description of Linux described in {{tcp-impl}} also applies to Cubic.
+
+### Assessment
+
+Both the specification and the Linux implementation limit the cwnd growth in accordance with Rate-Limited Increase;
+in Congestion Avoidance, this limit is more conservative than Rate-Limited Increase,
+and in Slow Start, it implements the "maxFS" upper limit of Rate-Limited Increase.
+
+## The Stream Control Transmission Protocol (SCTP)
+
+### Specification
+
+{{Section 7.2.1 of !RFC9260}} says:
+
+>When cwnd is less than or equal to ssthresh, an SCTP endpoint MUST use the slow-start algorithm to
+increase cwnd only if the current congestion window is being fully utilized and the data sender
+is not in Fast Recovery.
+Only when these two conditions are met can the cwnd be increased; otherwise, the cwnd MUST NOT be increased.
+
+### Assessment
+
+The quoted statement from {{!RFC9260}} prescribes the same cwnd growth limitation that is also specified for Cubic and implemented for both Reno and Cubic in Linux.
+It is in accordance with Rate-Limited Increase, and more conservative.
+
+{{Section 7.2.1 of !RFC9260}} is specifically limited to Slow Start.
+Congestion Avoidance is discussed in {{Section 7.2.2 of !RFC9260}}
+However, this section neither contains a similar rule nor does it refer back to the rule that limits the growth of cwnd
+in Section 7.2.1. It is thus implicitly clear that the quoted rule only applies to Slow Start, whereas Rate-Limited Increase applies to both Slow Start and Congestion Avoidance.
+
+## The QUIC Transport Protocol
+
+### Specification
+
+{{Section 7.8 of !RFC9002}} states:
+
+>When bytes in flight is smaller than the congestion window and sending is not pacing limited, the congestion window is underutilized. This can happen due to insufficient application data or flow control limits. When this occurs, the congestion window SHOULD NOT be increased in either slow start or congestion avoidance.
+
+### Assessment
+
+With the exception of pacing, this specification conservatively limits the growth in cwnd, similar to Cubic and SCTP. It is in accordance with Rate-Limited Increase, and more conservative.
 
 
 # Security Considerations
@@ -315,104 +411,6 @@ Received 10 ACKs; maxFS=20000, if (cwnd<2*maxFS) {cwnd +=ACK’ed}
 Note: In this round, maxFS was increased and cwnd was increased to 2*maxFS.
 
 
-# The state of RFCs and implementations
-
-RFC-Ed Note: This section is provided as input for IETF discussion, and should be removed before publication.
-
-## TCP ("Reno" congestion control)
-
-### Specification
-
-{{?RFC7661}} suggested there was no increase limitation in the standard TCP behavior (which {{?RFC7661}} changes), on page 4:
-
->Standard TCP does not impose additional restrictions on the growth of
-the congestion window when a TCP sender is unable to send at the
-maximum rate allowed by the cwnd. In this case, the rate-limited
-sender may grow a cwnd far beyond that corresponding to the current
-transmit rate, resulting in a value that does not reflect current
-information about the state of the network path the flow is using.
-
-### Implementation {#tcp-impl}
-
-- ns-2 allows cwnd to grow when it is rate-limited by rwnd. (Rate-limited by the sending application: not tested.)
-- Until release 3.42, ns-3 allowed cwnd to grow when rate-limited, either due to an application or rwnd limit.  Since release 3.42, ns-3 TCP models conform to Rate-Limited Increase, following the current Linux TCP approach in this regard (see next bullet).
-- In Congestion Avoidance, Linux only allows the cwnd to grow when the sender is unconstrained.
-Before kernel version 3.16, this also applied to Slow Start.
-The check for "unconstrained" is performed by checking if FlightSize is greater or equal to cwnd.
-Since kernel version 3.16, which was published in August 2014, in Slow Start, the increase
-implements Rate-Limited Increase in the `tcp_is_cwnd_limited` function in `tcp.h`.
-
-### Assessment
-
-Linux implements a limit to cwnd growth in accordance with Rate-Limited Increase;
-in Slow Start, this limit follows the rule's upper limit, while in Congestion Avoidance, it is more conservative than Rate-Limited Increase.
-The specification and the ns-2 and (older) ns-3 implementations are in conflict with Rate-Limited Increase.
-
-## CUBIC
-
-### Specification
-
-{{Section 5.8 of !RFC9438}} says:
-
->Cubic doesn't increase cwnd when it's limited by the sending application or rwnd.
-
-### Implementation
-
-The description of Linux described in {{tcp-impl}} also applies to Cubic.
-
-### Assessment
-
-Both the specification and the Linux implementation limit the cwnd growth in accordance with Rate-Limited Increase;
-in Congestion Avoidance, this limit is more conservative than Rate-Limited Increase,
-and in Slow Start, it implements the "maxFS" upper limit of Rate-Limited Increase.
-
-## The Stream Control Transmission Protocol (SCTP)
-
-### Specification
-
-{{Section 7.2.1 of !RFC9260}} says:
-
->When cwnd is less than or equal to ssthresh, an SCTP endpoint MUST use the slow-start algorithm to
-increase cwnd only if the current congestion window is being fully utilized and the data sender
-is not in Fast Recovery.
-Only when these two conditions are met can the cwnd be increased; otherwise, the cwnd MUST NOT be increased.
-
-### Assessment
-
-The quoted statement from {{!RFC9260}} prescribes the same cwnd growth limitation that is also specified for Cubic and implemented for both Reno and Cubic in Linux.
-It is in accordance with Rate-Limited Increase, and more conservative.
-
-{{Section 7.2.1 of !RFC9260}} is specifically limited to Slow Start.
-Congestion Avoidance is discussed in {{Section 7.2.2 of !RFC9260}}
-However, this section neither contains a similar rule nor does it refer back to the rule that limits the growth of cwnd
-in Section 7.2.1. It is thus implicitly clear that the quoted rule only applies to Slow Start, whereas Rate-Limited Increase applies to both Slow Start and Congestion Avoidance.
-
-## The QUIC Transport Protocol
-
-### Specification
-
-{{Section 7.8 of !RFC9002}} states:
-
->When bytes in flight is smaller than the congestion window and sending is not pacing limited, the congestion window is underutilized. This can happen due to insufficient application data or flow control limits. When this occurs, the congestion window SHOULD NOT be increased in either slow start or congestion avoidance.
-
-### Assessment
-
-With the exception of pacing, this specification conservatively limits the growth in cwnd, similar to Cubic and SCTP. It is in accordance with Rate-Limited Increase, and more conservative.
-
-## The Datagram Congestion Control Protocol (DCCP) CCID2
-
-### Specification
-
-{{Section 5.1 of ?RFC4341}} states:
-
->There are currently no standards governing TCP's use of the congestion window during an application-limited period.  In particular, it is possible for TCP's congestion window to grow quite large during a long uncongested period when the sender is application limited, sending at a low rate.  {{?RFC2861}} essentially suggests that TCP's congestion window not be increased during application-limited periods when the congestion window is not being fully utilized.
-
-### Assessment
-
-A DCCP Congestion Control ID (CCID) specifying TCP-like behaviour ought to follow the method specified in this document. The current guidance relates only to {{?RFC2861}}.
-The text in {{Section 5.1 of ?RFC4341}} is updated by this document to specify the management of the
-cwnd when the sender is rate-limited.
-
 
 # Change Log
 
@@ -446,6 +444,20 @@ cwnd when the sender is rate-limited.
   * Cleaned language and improved text explaining how this complements RFC7661.
   * Checked/updated definitions.
   * Added an example with cwnd in bytes.
+* draft-ietf-ccwg-ratelimited-increase-04
+  * Repeated definitions from RFC 7661 instead of just pointing at the RFC
+  * Made RFC 7661 informational
+* draft-ietf-ccwg-ratelimited-increase-05
+  * Rephrased references to RFC 7661
+  * Nits
+* draft-ietf-ccwg-ratelimited-increase-06
+  * Changed some TCP-specific language so it applies to QUIC too
+  * RFC 4341 added to list of updated RFCs in the abstract
+  * Nits
+* draft-ietf-ccwg-ratelimited-increase-07
+  * Updated this list
+  * Made RFC 4341 reference normative
+  * Moved appendix B into the main text as a new section that (only) defines the RFC updates.
 
 
 # Acknowledgments


### PR DESCRIPTION
This doesn't change the actual appendix B text yet. Because the change is so big, I thought it's easier to do this in two steps.